### PR TITLE
Add option -c to match windows with only class name list

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,13 +1,14 @@
-# Maintainer: slowpoke <mail+aur at slowpoke dot io>
+# Maintainer: tyjak <dev at tyjak dot net>
+_pkgname='quickswitch-for-i3'
 pkgname='quickswitch-i3'
-pkgver=2.7.0
+pkgver=2.8.0
 pkgrel=1
 pkgdesc="quickly change to and locate windows in i3"
 arch=(any)
-url="https://github.com/OliverUv/quickswitch-for-i3"
+url="https://github.com/tyjak/quickswitch-for-i3"
 license=('WTFPL')
 groups=()
-depends=('i3-wm' 'python' 'i3-py-git' 'dmenu')
+depends=('i3-wm' 'python' 'python-i3-py' 'dmenu')
 makedepends=()
 provides=()
 conflicts=()
@@ -15,11 +16,11 @@ replaces=()
 backup=()
 options=(!emptydirs)
 install=
-source=("http://pypi.python.org/packages/source/q/quickswitch-i3/quickswitch-i3-${pkgver}.tar.gz")
-md5sums=('92ea72936ae4879b002e50ae165b1457')
+source=("https://github.com/tyjak/$_pkgname/archive/$pkgver.tar.gz")
+md5sums=('SKIP')
 
 package() {
-  cd "$srcdir/$pkgname-$pkgver"
+  cd "$srcdir/$_pkgname-$pkgver"
   python setup.py install --root="$pkgdir/" --optimize=1
 }
 

--- a/quickswitch.py
+++ b/quickswitch.py
@@ -41,6 +41,7 @@ __version__ = "2.7.0"
 workspace_number_re = re.compile("^(?P<number>\d+)(?P<name>.*)")
 default_dmenu_command = "dmenu -b -i -l 20"
 window_class_ignore_list = []
+window_class_only_list = []
 follow = False
 follow_if_empty = False
 
@@ -298,6 +299,14 @@ def create_lookup_table(windows):
                 break
         if ignore_window:
             continue
+        if window_class_only_list:
+            only_window = True
+            for cn in window_class_only_list:
+                if win_class != cn:
+                    only_window = False
+                    break
+            if not only_window:
+                continue
         win_name = get_lookup_title(window)
         if win_name in lookup:
             # duplicate name of previous window
@@ -399,6 +408,11 @@ def set_ignore_class_list(str_list):
     window_class_ignore_list = str_list.split(",")
 
 
+def set_only_class_list(str_list):
+    global window_class_only_list
+    window_class_only_list = str_list.split(",")
+
+
 def main():
     parser = argparse.ArgumentParser(description="""quickswitch for i3""")
 
@@ -469,6 +483,9 @@ def main():
     parser.add_argument("-C", "--ignore-classes", default="",
                         help="comma separated list of window classes "
                         "to ignore")
+    parser.add_argument("-c", "--only-classes", default="",
+                        help="comma separated list of window classes "
+                        "to match only")
     parser.add_argument("-d", "--dmenu", default=default_dmenu_command,
                         help="dmenu command, executed within a shell")
     parser.add_argument("-i", "--insensitive", default=False,
@@ -503,6 +520,10 @@ def main():
     # initialize window_class_ignore_list
     if args.ignore_classes:
         set_ignore_class_list(args.ignore_classes)
+
+    # initialize window_class_only_list
+    if args.only_classes:
+        set_only_class_list(args.only_classes)
 
     # ...and regex search...
     if args.regex:

--- a/quickswitch.py
+++ b/quickswitch.py
@@ -441,12 +441,12 @@ def main():
                           action="store_true",
                           help="list scratchpad windows instead of "
                           "regular ones")
-    mutgrp_3.add_argument("-c", "--current", default=False,
-                          action="store_true",
-                          help="list only window in current workspaces")
     mutgrp_3.add_argument("-w", "--workspaces", default=False,
                           action="store_true",
                           help="list workspaces instead of windows")
+    mutgrp_3.add_argument("-W", "--windows", default=False,
+                          action="store_true",
+                          help="list only window in current workspaces")
     mutgrp_3.add_argument("-e", "--empty", default=False,
                           action="store_true",
                           help="go to the first empty, numbered "
@@ -573,7 +573,7 @@ def main():
     if args.workspaces:
         lookup_func = get_workspaces
         unit = "workspace"
-    if args.current:
+    if args.windows:
         lookup_func = get_current_windows
         unit = "window"
 

--- a/quickswitch.py
+++ b/quickswitch.py
@@ -41,6 +41,7 @@ __version__ = "2.7.0"
 workspace_number_re = re.compile("^(?P<number>\d+)(?P<name>.*)")
 default_dmenu_command = "dmenu -b -i -l 20"
 window_class_ignore_list = []
+window_class_only_list = []
 follow = False
 follow_if_empty = False
 
@@ -269,6 +270,14 @@ def create_lookup_table(windows):
                 break
         if ignore_window:
             continue
+        if window_class_only_list:
+            only_window = True
+            for cn in window_class_only_list:
+                if win_class != cn:
+                    only_window = False
+                    break
+            if not only_window:
+                continue
         win_name = get_lookup_title(window)
         if win_name in lookup:
             # duplicate name of previous window
@@ -370,6 +379,11 @@ def set_ignore_class_list(str_list):
     window_class_ignore_list = str_list.split(",")
 
 
+def set_only_class_list(str_list):
+    global window_class_only_list
+    window_class_only_list = str_list.split(",")
+
+
 def main():
     parser = argparse.ArgumentParser(description="""quickswitch for i3""")
 
@@ -437,6 +451,9 @@ def main():
     parser.add_argument("-C", "--ignore-classes", default="",
                         help="comma separated list of window classes "
                         "to ignore")
+    parser.add_argument("-c", "--only-classes", default="",
+                        help="comma separated list of window classes "
+                        "to match only")
     parser.add_argument("-d", "--dmenu", default=default_dmenu_command,
                         help="dmenu command, executed within a shell")
     parser.add_argument("-i", "--insensitive", default=False,
@@ -471,6 +488,10 @@ def main():
     # initialize window_class_ignore_list
     if args.ignore_classes:
         set_ignore_class_list(args.ignore_classes)
+
+    # initialize window_class_only_list
+    if args.only_classes:
+        set_only_class_list(args.only_classes)
 
     # ...and regex search...
     if args.regex:


### PR DESCRIPTION
Option to obtain a list of windows that only match classes pass in argument

Useful with my favorite web browser [vimb](https://fanglingsu.github.io/vimb/):
`nmap <Tab> :shell quickswitch -c Vimb -d "dmenu -l 12 -b -i -h 12"<CR>`
with these mapping in Vimb config file, it fires up a list of all my vimb window.