### PR TITLE
Use raw string for regex

### DIFF
--- a/quickswitch.py
+++ b/quickswitch.py
@@ -38,7 +38,7 @@ except ImportError:
 # Must use semver 2.0.0
 __version__ = "2.7.0"
 
-workspace_number_re = re.compile("^(?P<number>\d+)(?P<name>.*)")
+workspace_number_re = re.compile(r"^(?P<number>\d+)(?P<name>.*)")
 default_dmenu_command = "dmenu -b -i -l 20"
 window_class_ignore_list = []
 follow = False


### PR DESCRIPTION
The \d in this regex is interpreted by python as an escaped unicode character.  We want it to mean "digit", which would be what \d indicates in a regex when read as two characters, not one unicode char.  Here we convert the backslash character to an escape character by prefixing the string with "r", turning it into a raw string.